### PR TITLE
Try exec

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@netflix-internal/kmd",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kmd-script",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "A weird little scripting language",
   "homepage": "https://github.com/Netflix-Skunkworks/kmd",
   "repository": {

--- a/src/commands/index.js
+++ b/src/commands/index.js
@@ -20,6 +20,7 @@ const trim = require('./trim')
 const debug = require('./debug')
 const print = require('./print')
 const defaultTo = require('./default-to')
+const tryExec = require('./try-exec')
 
 module.exports = {
   pipe,
@@ -43,5 +44,6 @@ module.exports = {
   noEmpty,
   trim,
   debug,
-  print
+  print,
+  tryExec
 }

--- a/src/commands/try-exec.js
+++ b/src/commands/try-exec.js
@@ -1,0 +1,12 @@
+const defaultExec = require('./exec')
+
+module.exports = defaultShellStr => async shellStr => {
+  try {
+    const stdout = await defaultExec(defaultShellStr)(shellStr)
+    return stdout
+  } catch (e) {
+    // don't complete hide the error
+    console.error(e)
+    return ''
+  }
+}


### PR DESCRIPTION
Currently there is no way to attempt `exec` but allow failures, this is preferable with top-level commands, but can cause issues with sub commands built from templates.

The `tryExec` command wraps `exec` in a try/catch block, logs error to `console.error` and returns an empty string.