### PR TITLE
Bool match command

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@netflix-internal/kmd",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kmd-script",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "description": "A weird little scripting language",
   "homepage": "https://github.com/Netflix-Skunkworks/kmd",
   "repository": {

--- a/src/commands/bool-match.js
+++ b/src/commands/bool-match.js
@@ -1,0 +1,17 @@
+const boolMatch = (opts) => {
+  if (typeof opts === 'string') opts = { regex: new RegExp(opts) }
+  else if (opts.constructor.name === 'RegExp') opts = { regex: opts }
+  let { regex, match } = opts
+  if (typeof match === 'undefined') {
+    if (regex.source.includes('(')) match = 1
+    else match = 0
+  }
+
+  return (str) => {
+    if (!str) return false
+    const m = str.match(regex)
+    if (m && m[match]) return true
+  }
+}
+
+module.exports = boolMatch

--- a/src/commands/index.js
+++ b/src/commands/index.js
@@ -1,49 +1,51 @@
-const pipe = require('./pipe')
+const as = require('./as')
+const boolMatch = require('./bool-match')
+const cat = require('./cat')
+const contains = require('./contains')
+const debug = require('./debug')
+const defaultTo = require('./default-to')
 const echo = require('./echo')
 const exec = require('./exec')
-const save = require('./save')
-const contains = require('./contains')
 const extract = require('./extract')
-const load = require('./load')
-const remove = require('./remove')
-const split = require('./split')
 const lines = require('./lines')
+const load = require('./load')
 const map = require('./map')
-const as = require('./as')
-const template = require('./template')
-const cat = require('./cat')
+const noEmpty = require('./no-empty')
 const parseDate = require('./parse-date')
 const parseInt = require('./parse-int')
-const noEmpty = require('./no-empty')
 const pathResolve = require('./path-resolve')
-const trim = require('./trim')
-const debug = require('./debug')
+const pipe = require('./pipe')
 const print = require('./print')
-const defaultTo = require('./default-to')
+const remove = require('./remove')
+const save = require('./save')
+const split = require('./split')
+const template = require('./template')
+const trim = require('./trim')
 const tryExec = require('./try-exec')
 
 module.exports = {
-  pipe,
-  echo,
-  exec,
-  save,
-  defaultTo,
-  extract,
-  load,
-  remove,
-  split,
-  lines,
-  map,
   as,
-  template,
+  boolMatch,
   cat,
   contains,
+  debug,
+  defaultTo,
+  echo,
+  exec,
+  extract,
+  lines,
+  load,
+  map,
+  noEmpty,
   parseDate,
   parseInt,
   pathResolve,
-  noEmpty,
-  trim,
-  debug,
+  pipe,
   print,
+  remove,
+  save,
+  split,
+  template,
+  trim,
   tryExec
 }

--- a/src/index.js
+++ b/src/index.js
@@ -48,7 +48,7 @@ const compile = (scriptSrc) => {
   if (!environmentSet) setKmdEnv({})
   // console.time('compile')
   const lines = indentationParser(scriptSrc.trim().split('\n').filter(line => line.trim().length > 0))
-  pipeline = makeBlock(lines)
+  const pipeline = makeBlock(lines)
   // console.timeEnd('compile')
   return pipeline
 }


### PR DESCRIPTION
Adds the ability to extract a boolean based on string matching.

Example:
```bash
#!/usr/bin/env kmd
exec diskutil list
split \n\n
  save _line
  extract Volume\s([\w\s]+)\s{2,}
  # defaulting to empty string prevents trim from throwing error
  # when no match is found
  defaultTo
  trim
  save label
  save name

  load _line
  # if string Encrypted is present, the disk is encrypted
  boolMatch Encrypted
  save encrypted

  # retrieve the disk path for the next call
  load _line
  extract (/dev/[a-z0-9]+)\s+
  save _path

  # each disk has to be run through
  # diskutil info to get the uuid
  template diskutil info '{_path}'
  tryExec
  defaultTo
  extract Partition UUID:\s+([A-Z0-9-]+)
  save uuid

  remove _path
  remove _line
noEmpty
save disks
```