### PR TITLE
Context variables in execution

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -52,7 +52,10 @@ const compile = (scriptSrc, variables = {}) => {
 
   const source = scriptSrc
   .trim()
-  .replace(REPLACEMENT_REGEX, match => variables[match] || match)
+  .replace(REPLACEMENT_REGEX, match => {
+    const key = match.substring(1, match.length-1);
+    return variables[key] || match
+  })
   .split('\n')
   .filter(line => line.trim().length > 0);
 

--- a/src/index.js
+++ b/src/index.js
@@ -54,7 +54,7 @@ const compile = (scriptSrc, variables = {}) => {
   .trim()
   .replace(REPLACEMENT_REGEX, match => {
     const key = match.substring(1, match.length-1);
-    return variables[key] || match
+    return variables.hasOwnProperty(key) ? variables[key] : match
   })
   .split('\n')
   .filter(line => line.trim().length > 0);

--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,8 @@ const indentationParser = require('./indentation')
 let commands = {}
 let environmentSet = false
 
+const REPLACEMENT_REGEX= /%[\w\d-_]+%/g;
+
 const makeLine = (line, lineNum) => {
   const [cmd, ...args] = line.trim().split(/\s+/)
   let singleArg = args.join(' ')
@@ -43,11 +45,18 @@ const setKmdEnv = (env = {}) => {
   commands = require('./commands/index')
 }
 
-const compile = (scriptSrc) => {
+const compile = (scriptSrc, variables = {}) => {
   // if setKmdEnv wasn't called, load up the commands, should only be called once
   if (!environmentSet) setKmdEnv({})
   // console.time('compile')
-  const lines = indentationParser(scriptSrc.trim().split('\n').filter(line => line.trim().length > 0))
+
+  const source = scriptSrc
+  .trim()
+  .replace(REPLACEMENT_REGEX, match => variables[match] || match)
+  .split('\n')
+  .filter(line => line.trim().length > 0);
+
+  const lines = indentationParser(source)
   const pipeline = makeBlock(lines)
   // console.timeEnd('compile')
   return pipeline
@@ -60,7 +69,7 @@ const run = async (fn, input) => {
   return result
 }
 
-const runScript = (scriptSrc) => run(compile(scriptSrc))
+const runScript = (scriptSrc, variables = {}) => run(compile(scriptSrc, variables))
 
 module.exports = {
   compile,

--- a/test/basic-execution.js
+++ b/test/basic-execution.js
@@ -1,8 +1,24 @@
 const tap = require('tap')
-const { runScript } = require('../src/run')
+const { runScript } = require('../src/index')
 
 tap.test('basic execution', async function(t) {
   const script = `echo hi`
   const output = await runScript(script)
   t.same(output, 'hi')
+})
+
+tap.test('variables in execution', async function(t) {
+  const script = `echo hi %var%`
+  const output = await runScript(script, {
+    var: 'friend'
+  })
+  t.same(output, 'hi friend')
+})
+
+tap.test('variables in execution missing', async function(t) {
+  const script = `echo hi %fren%`
+  const output = await runScript(script, {
+    var: 'friend'
+  })
+  t.same(output, 'hi %fren%')
 })

--- a/test/basic-execution.js
+++ b/test/basic-execution.js
@@ -1,24 +1,26 @@
-const tap = require('tap')
-const { runScript } = require('../src/index')
+const tap = require('tap');
+const { runScript } = require('../src/index');
 
 tap.test('basic execution', async function(t) {
-  const script = `echo hi`
-  const output = await runScript(script)
-  t.same(output, 'hi')
-})
+  const script = `echo hi`;
+  const output = await runScript(script);
+  t.same(output, 'hi');
+});
 
 tap.test('variables in execution', async function(t) {
-  const script = `echo hi %var%`
+  const script = `echo hi %adj% %noun%`;
   const output = await runScript(script, {
-    var: 'friend'
-  })
-  t.same(output, 'hi friend')
-})
+    noun: 'friend',
+    adj: 'fabulous',
+  });
+  t.same(output, 'hi fabulous friend');
+});
 
 tap.test('variables in execution missing', async function(t) {
-  const script = `echo hi %fren%`
+  const script = `echo hi %adj% %noun%`;
   const output = await runScript(script, {
-    var: 'friend'
-  })
-  t.same(output, 'hi %fren%')
-})
+    var: 'friend',
+    adj: 'missing',
+  });
+  t.same(output, 'hi missing %noun%');
+});


### PR DESCRIPTION
Add the ability to pass context variables to be used when executing a script. This allows for outside context to be passed to the commands